### PR TITLE
Set up travis for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "node"
+cache:
+  directories:
+    - node_modules
+script:
+  - npm run clean
+  - npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stargazer
 
+[![Build Status](https://travis-ci.org/future-tense/stargazer.svg?branch=set-up-travis-for-builds)](https://travis-ci.org/future-tense/stargazer)
+
 A wallet application for the [Stellar](https://stellar.org) platform. Desktop and Mobile.
 
 


### PR DESCRIPTION
Hi there,

if I understood #71 correctly this PR should solve it. Is this what you had in mind or was there more to it?

I decided to use the last stable node version for the build (`- "node"`), because I couldn't find any dependency of stargazer to a pinned node version. In order for everything to work you have to enable travis for your repository (via https://travis-ci.com/).

Thanks!